### PR TITLE
Feature: allow retention of configuration file / fixes apt-get upgrade issue.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default['dataloop']['agent']['install_method'] = 'package' # package or bash
+default['dataloop']['agent']['keep_old_config'] = nil # or true to keep old config
 default['dataloop']['agent']['version'] = nil
 default['dataloop']['agent']['solo_mode'] = 'no'
 default['dataloop']['agent']['debug'] = 'no'

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -24,6 +24,9 @@ when 'rhel', 'fedora'
   package_install_opts = ''
 when 'debian'
   package_install_opts = ''
+  if node['dataloop']['agent']['keep_old_config'] then
+    package_install_opts = '-o Dpkg::Options::="--force-confold"'
+  end
 end
 
 package "dataloop-agent" do


### PR DESCRIPTION
This change has been written to support keeping the old config file
around because of an interaction with upgrades, and the local config
settings causing the agent to stop working.

The change adds an attribute, which if set causes debian systems to keep
the old version of the config.

---

This is the error this change resolves:

       Recipe: dataloop-agent::package
         * apt_package[dataloop-agent] action upgrade

           ================================================================================
           Error executing action `upgrade` on resource 'apt_package[dataloop-agent]'
           ================================================================================

           Mixlib::ShellOut::ShellCommandFailed
           ------------------------------------
           Expected process to exit with [0], but received '100'
           ---- Begin output of apt-get -q -y install dataloop-agent=1.4.5-1 ----
           STDOUT: Reading package lists...
           Building dependency tree...
           Reading state information...
           The following packages will be upgraded:
             dataloop-agent
           1 upgraded, 0 newly installed, 0 to remove and 122 not upgraded.
           Need to get 47.0 MB of archives.
           After this operation, 679 kB of additional disk space will be used.
           Get:1 https://download.dataloop.io/deb/ stable/main dataloop-agent amd64 1.4.5-1 [47.0 MB]
           Fetched 47.0 MB in 5s (8569 kB/s)
           (Reading database ... 74253 files and directories currently installed.)
           Preparing to unpack .../dataloop-agent_1.4.5-1_amd64.deb ...
            * Stopping Dataloop Agent
            * Stopping dataloop-agent daemon:
            * Deregistering dataloop-agent....
           2017-08-16 20:41:53 INFO dataloop_agent.context - Detected Default Host: fa:16:3e:a2:fe:82
           2017-08-16 20:41:53 INFO dataloop_agent.context - Detected Default Host: fa:16:3e:a2:fe:82
       ...done.
       ...done.
           Unpacking dataloop-agent (1.4.5-1) over (1.3.65-1) ...
           dataloop-agent has been uninstalled!
           Processing triggers for ureadahead (0.100.0-16) ...
           Setting up dataloop-agent (1.4.5-1) ...
           STDERR: dpkg: warning: unable to delete old directory '/opt/dataloop/embedded/lib/python2.7/site-packages/requests/packages/chardet': Directory not empty
           dpkg: warning: unable to delete old directory '/opt/dataloop/embedded/lib/python2.7/site-packages/requests/packages/urllib3/contrib': Directory not empty
           dpkg: warning: unable to delete old directory '/opt/dataloop/embedded/lib/python2.7/site-packages/requests/packages/urllib3/packages/ssl_match_hostname': Directory not empty
           dpkg: warning: unable to delete old directory '/opt/dataloop/embedded/lib/python2.7/site-packages/requests/packages/urllib3/packages': Directory not empty
           dpkg: warning: unable to delete old directory '/opt/dataloop/embedded/lib/python2.7/site-packages/requests/packages/urllib3/util': Directory not empty
           dpkg: warning: unable to delete old directory '/opt/dataloop/embedded/lib/python2.7/site-packages/requests/packages/urllib3': Directory not empty
           dpkg: warning: unable to delete old directory '/opt/dataloop/embedded/lib/python2.7/site-packages/requests/packages': Directory not empty

           Configuration file '/etc/dataloop/agent.yaml'
            ==> Modified (by you or by a script) since installation.
            ==> Package distributor has shipped an updated version.
       What would you like to do about it ?  Your options are:
        Y or I  : install the package maintainer's version
        N or O  : keep your currently-installed version
          D     : show the differences between the versions
          Z     : start a shell to examine the situation
            The default action is to keep your current version.
           *** agent.yaml (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package dataloop-agent (--configure):
            EOF on stdin at conffile prompt
           Errors were encountered while processing:
            dataloop-agent
           E: Sub-process /usr/bin/dpkg returned an error code (1)
           ---- End output of apt-get -q -y install dataloop-agent=1.4.5-1 ----
           Ran apt-get -q -y install dataloop-agent=1.4.5-1 returned 100

           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/dataloop-agent/recipes/package.rb

            29: package "dataloop-agent" do
            30:   version node['dataloop']['agent']['version']
            31:   options package_install_opts
            32:   action :upgrade
            33: end

           Compiled Resource:
           ------------------
           # Declared in /tmp/kitchen/cache/cookbooks/dataloop-agent/recipes/package.rb:29:in `from_file'

           apt_package("dataloop-agent") do
             package_name "dataloop-agent"
             action [:upgrade]
             retries 0
             retry_delay 2
             default_guard_interpreter :default
             declared_type :package
             cookbook_name "dataloop-agent"
             recipe_name "package"
             version "1.4.5-1"
           end

           Platform:
           ---------
           x86_64-linux

